### PR TITLE
Fix stop hook

### DIFF
--- a/tasks/LaserScanner.cpp
+++ b/tasks/LaserScanner.cpp
@@ -277,12 +277,11 @@ void LaserScanner::errorHook()
 }
 
 
-
 void LaserScanner::stopHook()
 {
-    RTT::TaskContext::stopHook();
-    
+    getActivity<RTT::extras::FileDescriptorActivity>()->clearAllWatches();
     laserdriver.close();
+    RTT::TaskContext::stopHook();
 }
 
 

--- a/tasks/LaserScanner.cpp
+++ b/tasks/LaserScanner.cpp
@@ -207,7 +207,7 @@ void LaserScanner::updateHook()
     {
         size = laserdriver.readPacket((uint8_t*)&buffer, VELODYNE_DATA_MSG_BUFFER_SIZE, timeout, timeout);
     }
-    catch (std::runtime_error e)
+    catch (const std::runtime_error & e)
     {
         RTT::log(RTT::Error) << TaskContext::getName() << ": " << e.what() << RTT::endlog();
         actual_state = IO_TIMEOUT;

--- a/tasks/Positioning.cpp
+++ b/tasks/Positioning.cpp
@@ -229,13 +229,9 @@ void Positioning::errorHook()
 
 void Positioning::stopHook()
 {
-    
-    RTT::TaskContext::stopHook();
-    
-
+    getActivity<RTT::extras::FileDescriptorActivity>()->clearAllWatches();
     positioning_driver.close();
-
-    
+    RTT::TaskContext::stopHook();
 }
 
 

--- a/tasks/Positioning.cpp
+++ b/tasks/Positioning.cpp
@@ -110,7 +110,7 @@ void Positioning::updateHook()
     {
         size = positioning_driver.readPacket((uint8_t*)&buffer, VELODYNE_POSITIONING_MSG_BUFFER_SIZE, timeout, timeout);
     }
-    catch (std::runtime_error e)
+    catch (const std::runtime_error & e)
     {
         RTT::log(RTT::Error) << TaskContext::getName() << ": " << e.what() << RTT::endlog();
         actual_state = IO_TIMEOUT;
@@ -185,7 +185,7 @@ void Positioning::updateHook()
             }
             
         }
-        catch (std::runtime_error e)
+        catch (const std::runtime_error & e)
         {
             RTT::log(RTT::Error) << TaskContext::getName() << ": " << e.what() << RTT::endlog();
             actual_state = IO_ERROR;


### PR DESCRIPTION
If this is not done, the console is flooded by `FileDescriptorActivity: error in select(), errno = 9` when the task is stopped
